### PR TITLE
v3.2.4 - Dismiss all checked, new checklist element on submit

### DIFF
--- a/notes/lib/model/note/checklist_group.dart
+++ b/notes/lib/model/note/checklist_group.dart
@@ -64,6 +64,10 @@ class ChecklistGroup {
     checkedElems.removeAt(idx);
   }
 
+  void removeCheckedElements() {
+    checkedElems.clear();
+  }
+
   void updateElementAt(int idx, ChecklistElement newElement) {
     uncheckedElems.removeAt(idx);
     uncheckedElems.insert(idx, newElement);

--- a/notes/lib/model/note/notifier/checklist_list.dart
+++ b/notes/lib/model/note/notifier/checklist_list.dart
@@ -55,6 +55,11 @@ class ChecklistManager extends ChangeNotifier {
     NotesList().modifyNote(note);
   }
 
+  void removeAllCheckedElementsFromGroup(int groupIdx) {
+    note.groups[groupIdx].removeCheckedElements();
+    NotesList().modifyNote(note);
+  }
+
   void removeUncheckedElementFromGroup(int groupIdx, int elementIdx) {
     note.groups[groupIdx].removeUncheckedElementAt(elementIdx);
     NotesList().modifyNote(note);

--- a/notes/lib/screen/checklist.dart
+++ b/notes/lib/screen/checklist.dart
@@ -59,6 +59,7 @@ class _ChecklistPageState extends State<ChecklistPage> {
                             style: const TextStyle(fontSize: 24),
                             decoration: const InputDecoration(
                               hintText: 'Note title',
+                              hintStyle: TextStyle(fontSize: 20, color: Color.from(alpha: 0.75, red: 1, green: 1, blue: 1)),
                               border: InputBorder.none,
                               counterText: '',
                             ),

--- a/notes/lib/screen/plaintext.dart
+++ b/notes/lib/screen/plaintext.dart
@@ -75,6 +75,10 @@ class _PlaintextPageState extends State<PlaintextPage> {
                             style: const TextStyle(fontSize: 24),
                             decoration: const InputDecoration(
                               hintText: 'Note title',
+                              hintStyle: TextStyle(
+                                  fontSize: 20,
+                                  color: Color.from(
+                                      alpha: 0.75, red: 1, green: 1, blue: 1)),
                               border: InputBorder.none,
                               counterText: '',
                             ),
@@ -107,6 +111,13 @@ class _PlaintextPageState extends State<PlaintextPage> {
                                 style: const TextStyle(fontSize: 20),
                                 decoration: const InputDecoration.collapsed(
                                   hintText: 'New note',
+                                  hintStyle: TextStyle(
+                                      fontSize: 20,
+                                      color: Color.from(
+                                          alpha: 0.75,
+                                          red: 1,
+                                          green: 1,
+                                          blue: 1)),
                                   border: InputBorder.none,
                                 ),
                               ),

--- a/notes/lib/widget/checklist_group_tile.dart
+++ b/notes/lib/widget/checklist_group_tile.dart
@@ -54,6 +54,10 @@ class _CLGroupTileState extends State<ChecklistGroupTile> {
                         style: const TextStyle(fontSize: 20),
                         decoration: const InputDecoration(
                           hintText: 'Group title',
+                          hintStyle: TextStyle(
+                              fontSize: 20,
+                              color: Color.from(
+                                  alpha: 0.75, red: 1, green: 1, blue: 1)),
                           border: InputBorder.none,
                           counterText: '',
                         ),
@@ -74,7 +78,7 @@ class _CLGroupTileState extends State<ChecklistGroupTile> {
                   physics: const NeverScrollableScrollPhysics(),
                   itemCount: manager.groupAt(widget.groupIdx).uncheckedLength,
                   itemBuilder: (context, index) {
-                    return ChecklistTile(widget.groupIdx, index, false);
+                    return ChecklistTile(widget.groupIdx, index, false, () => _onTapAddElement());
                   },
                 ),
                 Padding(
@@ -121,14 +125,39 @@ class _CLGroupTileState extends State<ChecklistGroupTile> {
                     ),
                   ),
                 ),
-                Visibility(
-                  visible: !_displayCheckedItems &&
-                      manager.note.groups[widget.groupIdx].checkedLength > 0,
-                  child: Center(
-                    child: Opacity(
-                      opacity: 0.75,
-                      child: Text(
-                        '${manager.note.groups[widget.groupIdx].checkedLength} checked item${manager.note.groups[widget.groupIdx].checkedLength != 1 ? 's' : ''}',
+                Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 10),
+                  child: Visibility(
+                    visible: !_displayCheckedItems &&
+                        manager.note.groups[widget.groupIdx].checkedLength > 0,
+                    child: Dismissible(
+                      key: UniqueKey(),
+                      direction: DismissDirection.endToStart,
+                      onDismissed: (direction) => _onDismissClearChecked(),
+                      background: Container(
+                        color: Colors.transparent,
+                      ),
+                      secondaryBackground: Container(
+                          alignment: Alignment.centerRight,
+                          child: Icon(
+                            Icons.delete_rounded,
+                            color: appTheme.theme.secondaryColor,
+                          )),
+                      child: Visibility(
+                        visible: !_displayCheckedItems &&
+                            manager.note.groups[widget.groupIdx].checkedLength >
+                                0,
+                        child: Center(
+                          child: Padding(
+                            padding: EdgeInsets.only(bottom: 5),
+                            child: Opacity(
+                              opacity: 0.75,
+                              child: Text(
+                                '${manager.note.groups[widget.groupIdx].checkedLength} checked item${manager.note.groups[widget.groupIdx].checkedLength != 1 ? 's' : ''}',
+                              ),
+                            ),
+                          ),
+                        ),
                       ),
                     ),
                   ),
@@ -151,14 +180,14 @@ class _CLGroupTileState extends State<ChecklistGroupTile> {
                         secondaryBackground: Container(
                           alignment: Alignment.centerRight,
                           child: Padding(
-                            padding: const EdgeInsets.only(right: 5),
+                            padding: const EdgeInsets.only(right: 10),
                             child: Icon(
                               Icons.delete_rounded,
                               color: appTheme.theme.secondaryColor,
                             ),
                           ),
                         ),
-                        child: ChecklistTile(widget.groupIdx, index, true),
+                        child: ChecklistTile(widget.groupIdx, index, true, () {}),
                       );
                     },
                   ),
@@ -175,7 +204,7 @@ class _CLGroupTileState extends State<ChecklistGroupTile> {
     ChecklistManager().updateGroupTitle(widget.groupIdx, newTitle);
   }
 
-  void _onTapRemoveCheckedElement(idx) {
+  void _onTapRemoveCheckedElement(int idx) {
     ChecklistManager().removeCheckedElementFromGroup(widget.groupIdx, idx);
     setState(() {});
   }
@@ -183,6 +212,11 @@ class _CLGroupTileState extends State<ChecklistGroupTile> {
   void _onTapAddElement() {
     ChecklistManager().addElementToGroup(widget.groupIdx);
     // NOTE change to consumer? it would still rebuild all groups...
+    setState(() {});
+  }
+
+  void _onDismissClearChecked() {
+    ChecklistManager().removeAllCheckedElementsFromGroup(widget.groupIdx);
     setState(() {});
   }
 

--- a/notes/lib/widget/checklist_tile.dart
+++ b/notes/lib/widget/checklist_tile.dart
@@ -9,8 +9,9 @@ class ChecklistTile extends StatefulWidget {
   final int groupIdx;
   final int elemIdx;
   final bool checked;
+  final Function onSubmitCallback;
 
-  const ChecklistTile(this.groupIdx, this.elemIdx, this.checked, {super.key});
+  const ChecklistTile(this.groupIdx, this.elemIdx, this.checked, this.onSubmitCallback, {super.key});
 
   @override
   State<ChecklistTile> createState() => _ChecklistTileState();
@@ -60,10 +61,11 @@ class _ChecklistTileState extends State<ChecklistTile> {
             maxLines: null,
             onChanged: _onContentModified,
             onSubmitted: _onContentSubmitted,
-            textInputAction: TextInputAction.done,
+            textInputAction: TextInputAction.next,
             style: const TextStyle(fontSize: 20),
             decoration: const InputDecoration(
               hintText: 'Item',
+              hintStyle: TextStyle(fontSize: 20, color: Color.from(alpha: 0.75, red: 1, green: 1, blue: 1)),
               border: InputBorder.none,
               counterText: '',
             ),
@@ -104,5 +106,6 @@ class _ChecklistTileState extends State<ChecklistTile> {
       _updateTimer!.cancel();
     }
     _contentUpdateCallback();
+    widget.onSubmitCallback();
   }
 }

--- a/notes/pubspec.yaml
+++ b/notes/pubspec.yaml
@@ -3,7 +3,7 @@ description: A simple Android app for taking notes.
 
 publish_to: 'none'
 
-version: 3.2.3+41
+version: 3.2.4+42
 
 environment:
   sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
This PR introduces the following:

- hint text is 75% opacity
- by dismissing the "x checked items" tile, all checked elements are deleted from group at once
- when tapping the keyboard submit action in a checklist item, a new unchecked item is added to the list ([as requested in this issue](https://github.com/rovati/noteapp/issues/9))